### PR TITLE
Fix platform list image dimensions

### DIFF
--- a/appstore/locker.py
+++ b/appstore/locker.py
@@ -44,7 +44,7 @@ def jsonify_locker_app(entry):
             'description': asset_fallback(assets, x.platform).description,
             'images': {
                 'icon': generate_image_url(app.icon_small, 48, 48, True),
-                'list': generate_image_url(app.icon_large, 144, 144, True),
+                'list': generate_image_url(app.icon_large, *plat_dimensions[x.platform], True),
                 'screenshot': generate_image_url(asset_fallback(assets, x.platform).screenshots[0],
                                                  *plat_dimensions[x.platform])
             }

--- a/appstore/locker.py
+++ b/appstore/locker.py
@@ -15,6 +15,7 @@ def jsonify_locker_app(entry):
     app = entry.app
     release = app.releases[-1] if len(app.releases) > 0 else None  # type: Release
     assets = app.asset_collections
+    is_watchface = app.type == "watchface"
 
     return {**{
         'id': app.id,
@@ -44,7 +45,7 @@ def jsonify_locker_app(entry):
             'description': asset_fallback(assets, x.platform).description,
             'images': {
                 'icon': generate_image_url(app.icon_small, 48, 48, True),
-                'list': generate_image_url(app.icon_large, *plat_dimensions[x.platform], True),
+                'list': generate_image_url(app.icon_large, *plat_dimensions[x.platform] if is_watchface else (144, 144), True),
                 'screenshot': generate_image_url(asset_fallback(assets, x.platform).screenshots[0],
                                                  *plat_dimensions[x.platform])
             }


### PR DESCRIPTION
The response is currently often a bad request as these images are screenshots and so match the platform dimensions.

I plan to use this for watchface locker images in cobble.