### PR TITLE
Compare version properly

### DIFF
--- a/appstore/developer_portal_api.py
+++ b/appstore/developer_portal_api.py
@@ -2,7 +2,7 @@ import json
 import traceback
 import datetime
 
-#from algoliasearch import algoliasearch
+from algoliasearch import algoliasearch
 from flask import Blueprint, jsonify, abort, request
 from flask_cors import CORS
 

--- a/appstore/developer_portal_api.py
+++ b/appstore/developer_portal_api.py
@@ -2,7 +2,7 @@ import json
 import traceback
 import datetime
 
-from algoliasearch import algoliasearch
+#from algoliasearch import algoliasearch
 from flask import Blueprint, jsonify, abort, request
 from flask_cors import CORS
 
@@ -12,7 +12,7 @@ from werkzeug.exceptions import BadRequest
 from sqlalchemy.exc import DataError
 from zipfile import BadZipFile
 
-from .utils import authed_request, demand_authed_request, get_uid, id_generator, validate_new_app_fields, is_valid_category, is_valid_appinfo, is_valid_platform, clone_asset_collection_without_images, is_valid_image_file, is_valid_image_size, get_max_image_dimensions, generate_image_url, is_users_developer_id, user_is_wizard, newAppValidationException, algolia_app
+from .utils import authed_request, demand_authed_request, get_uid, id_generator, validate_new_app_fields, is_valid_category, is_valid_appinfo, is_valid_platform, clone_asset_collection_without_images, is_valid_image_file, is_valid_image_size, get_max_image_dimensions, generate_image_url, is_users_developer_id, user_is_wizard, newAppValidationException, algolia_app, first_version_is_newer
 from .models import Category, db, App, Developer, Release, CompanionApp, Binary, AssetCollection, LockerEntry, UserLike
 from .pbw import PBW, release_from_pbw
 from .s3 import upload_pbw, upload_asset
@@ -304,7 +304,7 @@ def submit_new_release(app_id):
 
     release_old = Release.query.filter_by(app=app).order_by(Release.published_date.desc()).first()
 
-    if version <= release_old.version:
+    if not first_version_is_newer(version, release_old.version):
         return jsonify(
             error=f"The version ({version}) is already on the appstore", 
             e="version.exists", 

--- a/appstore/utils.py
+++ b/appstore/utils.py
@@ -505,3 +505,21 @@ def who_am_i():
     result = demand_authed_request('GET', f"{config['REBBLE_AUTH_URL']}/api/v1/me")
     me = result.json()
     return f'{me["name"]} ({me["uid"]})'
+
+def first_version_is_newer(current_release, old_release):
+    #1.11 is < 1.1 (mathmatically) so split up by . and check properly
+    sections_current = str(current_release).split(".")
+    sections_old = str(old_release).split(".")
+    for i in range(len(sections_current)):
+        try:
+            current = int(sections_current[i])
+            old = int(sections_old[i])
+            if current > old:
+                return True
+            elif old > current:
+                return False
+        except IndexError:
+            # Current version is longer than old version. I.e. 1.2.1 vs 1.2
+            # As long as it's not 0, current is newer
+            return current != 0
+    return False

--- a/appstore/utils.py
+++ b/appstore/utils.py
@@ -522,4 +522,8 @@ def first_version_is_newer(current_release, old_release):
             # Current version is longer than old version. I.e. 1.2.1 vs 1.2
             # As long as it's not 0, current is newer
             return current != 0
+        except ValueError:
+            # The field is a string so it might not be a number
+            # In such a case we can't compare so just fail until they change it
+            return False
     return False


### PR DESCRIPTION
Currently the dev portal just checks that new_version > old_version.

This is fine for 1.1 > 1, or 0.26 > 0.1. But it breaks for 0.11 > 0.1 because maths. 
It also doesn't support more than one decimal (not sure if we should be mind)

This fix splits by decimal point then compares a section at a time.