### PR TITLE
Handle unexpected suffix "-rbl" in version comparison

### DIFF
--- a/appstore/utils.py
+++ b/appstore/utils.py
@@ -513,7 +513,10 @@ def first_version_is_newer(current_release, old_release):
     for i in range(len(sections_current)):
         try:
             current = int(sections_current[i])
-            old = int(sections_old[i])
+            # Some apps updated manually via Rebble have the "-rbl" suffix, e.g. "1.0-rbl"
+            # We have to remove the suffix here otherwise the comparison always fail
+            old_numeric_part = sections_old[i].split("-")[0]
+            old = int(old_numeric_part)
             if current > old:
                 return True
             elif old > current:


### PR DESCRIPTION
Hello, thank you for keeping Pebble alive!

I tried to update [a watchface](https://apps.rebble.io/en_US/application/58237be0b62cefad1500001b/changelog) I previously updated via an older Rebble interface, and it didn't go well.
I realised it had an irregular version of `1.0-rbl`, which I suppose was manually created by the staff, as such version was impossible to create with the `pebble build` command.

Such version casuses trouble when updating via the current Rebble Dev Portal, as the current version comparison function (reasonably) expect a version to be numbers separated by dots.

I workedaround the issue by making the new version `2.0`, but it would be better if it's handled properly.
Please let me know if this is the only irregular case or am I still missing something.

Cheers
