### PR TITLE
Sync to Algolia after new release upload

### DIFF
--- a/appstore/developer_portal_api.py
+++ b/appstore/developer_portal_api.py
@@ -360,6 +360,22 @@ def submit_new_release(app_id):
     App.query.filter_by(id=app_id).update({'updated_at': datetime.datetime.utcnow()})
     db.session.commit()
 
+    # Sync the new release to Algolia so search results reflect the new
+    # version, release notes, and compatibility. Without this, the app
+    # store search keeps returning whatever version was last indexed by
+    # submit_new_app / update_app.
+    # algolia_app(app) reads app.releases[0]; with the default
+    # expire_on_commit=True the relationship is reloaded on next access
+    # and includes the release we just added (ordered by published_date DESC).
+    # Wrapped in try/except like the Discord/Discourse announcements below
+    # so a transient Algolia outage can't make a successful release look
+    # like a failure to the developer (the release is already committed).
+    if algolia_index and app.visible:
+        try:
+            algolia_index.partial_update_objects([algolia_app(app)], { 'createIfNotExists': True })
+        except Exception as e:
+            print(f"Algolia is being weird: {repr(e)}")
+
     if app.visible:
         try:
             discord.announce_release(app, release_new, pbw.is_generated())


### PR DESCRIPTION
## Summary

`submit_new_release` (`POST /app/<app_id>/release`) commits the new release to the database and announces it on Discord/Discourse, but never updates the Algolia search index. Every other mutation in [`developer_portal_api.py`](appstore/developer_portal_api.py) — `submit_new_app`, `update_app`, the visibility flips — calls `algolia_index.partial_update_objects`. Release uploads have been missed since the file was first added.

The visible result: when a developer uploads a new version, the rebble.io website (which reads from the DB) shows the new version, but the app store search index keeps returning whatever version was most recently captured by an app-metadata update. For example, **Timer Core** currently shows `1.3.0` on rebble.io but returns `1.0` to clients hitting the Algolia search index. **Dungeon Escape** showed a similar pattern on the Pebble Appstore side (also recently fixed in our backend).

This was [reported on the Pebble mobile app](https://github.com/coredevices/mobileapp/issues/188) where users notice "wrong" search results when both Pebble and Rebble app stores are enabled — the mobile app's dedup comparator picks whichever indexed version is higher, and the stale Rebble entries skew the choice.

## What changed

Mirror the existing pattern after the DB commit in `submit_new_release`:

```python
if algolia_index and app.visible:
    try:
        algolia_index.partial_update_objects([algolia_app(app)], { 'createIfNotExists': True })
    except Exception as e:
        print(f"Algolia is being weird: {repr(e)}")
```

- The default `expire_on_commit=True` means `app.releases` will be reloaded fresh on next access, picking up the release we just inserted (the relationship is ordered by `published_date DESC`).
- `createIfNotExists=True` matches the `set_app_visbility` re-publish path so a missing index entry gets created rather than silently no-op'd.
- The `try/except` matches the Discord/Discourse pattern just below — a transient Algolia error shouldn't make a successful release look like a failure to the developer (the release is already durably committed).

## Test plan

- [ ] Upload a new release for a visible app and confirm the Algolia hit reflects the new `version`, `release_notes`, and `compatibility` within a few seconds.
- [ ] Upload a release for an invisible app and confirm Algolia is **not** touched (existing `app.visible` guard).
- [ ] Simulate an Algolia outage (or invalid API key) and confirm the endpoint still returns 200 and the Discord/Discourse announcements still fire.

## Notes / not in scope

- There's a latent issue with `app.releases[0]` in [`algolia_app`](appstore/utils.py#L237): the relationship is `order_by=desc(Release.published_date)`, and Postgres' default `DESC` puts NULLs first. Any release with a NULL `published_date` would be picked over a newly inserted one. `release_from_pbw` always sets `published_date=utcnow()`, so this only bites imported/legacy data — but adding `nullslast()` to the model would be a worthwhile follow-up.